### PR TITLE
Dependabot: align with HA pins (ignore protobuf; block httpx major)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,11 @@ updates:
     labels: ["dependencies", "python"]
     commit-message:
       prefix: "deps(pip)"
-    # Example: avoid auto PRs for protobuf major bumps
+    # Do not allow updates beyond HA-pinned packages
+    # Completely ignore protobuf bumps; keep aligned with HA
     ignore:
       - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      # Allow httpx, but block major upgrades to reduce breakage risk
+      - dependency-name: "httpx"
         update-types: ["version-update:semver-major"]
-


### PR DESCRIPTION
Updates Dependabot config to prevent bumps beyond Home Assistant pins:\n\n- Ignore protobuf entirely (HA currently pins to 6.32.0)\n- Block httpx major updates (allow only minor/patch)\n\nThis keeps Dependabot PRs within HA-supported ranges. We still mirror deps in requirements.txt for visibility, but we only adopt approved updates in manifest.json.