### PR TITLE
Prettier: format dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,41 @@
 version: 2
 updates:
   # Keep GitHub Actions up to date
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
+      interval: weekly
+      day: monday
+      time: '08:00'
     open-pull-requests-limit: 5
-    labels: ["dependencies", "ci"]
+    labels:
+      - dependencies
+      - ci
 
   # Track Python deps via a simple requirements.txt mirror
   # Note: Home Assistant installs deps from manifest.json; Dependabot
   # does not read that file, so we mirror here for update PRs/alerts.
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
+      interval: weekly
+      day: monday
+      time: '08:00'
     open-pull-requests-limit: 5
-    labels: ["dependencies", "python"]
+    labels:
+      - dependencies
+      - python
     commit-message:
-      prefix: "deps(pip)"
+      prefix: deps(pip)
     # Do not allow updates beyond HA-pinned packages
     # Completely ignore protobuf bumps; keep aligned with HA
     ignore:
-      - dependency-name: "protobuf"
-        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: protobuf
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+          - version-update:semver-patch
       # Allow httpx, but block major upgrades to reduce breakage risk
-      - dependency-name: "httpx"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: httpx
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Fix Prettier YAML Check by formatting .github/dependabot.yml to Prettier style (no quotes where unnecessary, multiline arrays).