### PR TITLE
Prettier: fix YAML time quoting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: '08:00'
+      time: "08:00"
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: '08:00'
+      time: "08:00"
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
Use double quotes for YAML time values (08:00) in .github/dependabot.yml so Prettier --check passes.